### PR TITLE
add unit tests for metrics and metricsfactory

### DIFF
--- a/kotlin/lib/src/main/kotlin/goodmetrics/Metrics.kt
+++ b/kotlin/lib/src/main/kotlin/goodmetrics/Metrics.kt
@@ -11,13 +11,33 @@ class Metrics internal constructor(
     sealed interface Dimension {
         val name: String
         val value: Any
-        data class Str(override val name: String, override val value: String): Dimension
-        data class Num(override val name: String, override val value: Long): Dimension
-        data class Bool(override val name: String, override val value: Boolean): Dimension
+        data class Str(override val name: String, override val value: String) : Dimension
+        data class Num(override val name: String, override val value: Long) : Dimension
+        data class Bool(override val name: String, override val value: Boolean) : Dimension
     }
     internal val metricMeasurements: MutableMap<String, Number> = mutableMapOf()
     internal val metricDistributions: MutableMap<String, Long> = mutableMapOf()
     internal val metricDimensions: MutableMap<String, Dimension> = mutableMapOf()
+
+    data class View(
+        val metricName: String,
+        val timestampMillis: Long,
+        val startNanoTime: Long,
+        val dimensions: Map<String, Dimension>,
+        val measurements: Map<String, Number>,
+        val distributions: Map<String, Long>,
+    )
+
+    fun getView(): View {
+        return View(
+            name,
+            timestampMillis,
+            startNanoTime,
+            metricDimensions.toMap(),
+            metricMeasurements.toMap(),
+            metricDistributions.toMap(),
+        )
+    }
 
     fun dimension(dimension: String, value: Boolean) {
         metricDimensions[dimension] = Dimension.Bool(dimension, value)

--- a/kotlin/lib/src/test/kotlin/goodmetrics/MetricsTest.kt
+++ b/kotlin/lib/src/test/kotlin/goodmetrics/MetricsTest.kt
@@ -1,0 +1,139 @@
+package goodmetrics
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class MetricsTest {
+    private lateinit var metricsFactory: MetricsFactory
+    private val emittedMetrics: MutableList<Metrics> = mutableListOf()
+    private var nowMillis = 0L
+
+    @BeforeTest
+    fun before() {
+        nowMillis = 0
+        emittedMetrics.clear()
+        metricsFactory = MetricsFactory(sink = emittedMetrics::add, epochMillis = { nowMillis })
+    }
+
+    @Test
+    fun testTimestampStart() {
+        nowMillis = 13
+        val metrics = metricsFactory.getMetrics("test", TimestampAt.Start)
+        metrics.assert(timestamp = 13)
+    }
+
+    @Test
+    fun testTimestampEnd() {
+        nowMillis = 13
+        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        metrics.assert(timestamp = -1)
+
+        nowMillis = 17
+        metricsFactory.emit(metrics)
+        metrics.assert(timestamp = 17)
+    }
+
+    @Test
+    fun testEmitEmits() {
+        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        assertEquals(listOf(), emittedMetrics)
+
+        metricsFactory.emit(metrics)
+        assertEquals(listOf(metrics), emittedMetrics)
+    }
+
+    @Test
+    fun testRecordEmits() {
+        // Don't ever let metrics references escape a record block!
+        // This is for a test assertion only.
+        var illegalUsage: Metrics
+        metricsFactory.record("test") { metrics ->
+            illegalUsage = metrics
+        }
+
+        assertEquals(listOf(illegalUsage), emittedMetrics)
+    }
+
+    @Test
+    fun testDimensionOverloads() {
+        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        metrics.dimension("1", true)
+        metrics.dimension("2", false)
+        metrics.dimension("3", 12L)
+        metrics.dimension("4", 17L)
+        metrics.dimension("5", "a")
+        metrics.dimension("6", "b")
+        metrics.assert(
+            dimensions = mapOf(
+                "1" to Metrics.Dimension.Bool("1", true),
+                "2" to Metrics.Dimension.Bool("2", false),
+                "3" to Metrics.Dimension.Num("3", 12),
+                "4" to Metrics.Dimension.Num("4", 17),
+                "5" to Metrics.Dimension.Str("5", "a"),
+                "6" to Metrics.Dimension.Str("6", "b"),
+            )
+        )
+    }
+
+    @Test
+    fun testMeasureOverloads() {
+        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        metrics.measure("1", 1L)
+        metrics.measure("2", 2L)
+        metrics.measure("3", 3)
+        metrics.measure("4", 4)
+        metrics.measure("5", 5.125)
+        metrics.measure("6", 6.250)
+        metrics.measure("7", 7.375f)
+        metrics.measure("8", 8.500f)
+        metrics.assert(
+            measurements = listOf(
+                "1" to 1L,
+                "2" to 2L,
+                // Ints are treated as longs in goodmetrics
+                "3" to 3L,
+                "4" to 4L,
+                "5" to 5.125,
+                "6" to 6.250,
+                // Floats are treated as Doubles in goodmetrics
+                "7" to 7.375,
+                "8" to 8.500,
+            )
+        )
+    }
+
+    @Test
+    fun testDistributionOverloads() {
+        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        metrics.distribution("1", 1L)
+        metrics.distribution("2", 2L)
+        metrics.distribution("3", 3)
+        metrics.distribution("4", 4)
+        metrics.assert(
+            distributions = mapOf(
+                "1" to 1L,
+                "2" to 2L,
+                "3" to 3,
+                "4" to 4,
+            )
+        )
+    }
+}
+
+fun Metrics.assert(timestamp: Long? = null, dimensions: Map<String, Metrics.Dimension>? = null, measurements: List<Pair<String, Number>>? = null, distributions: Map<String, Long>? = null) {
+    val view = getView()
+    if (timestamp != null) {
+        assertEquals(timestamp, view.timestampMillis)
+    }
+    if (dimensions != null) {
+        assertEquals(dimensions, view.dimensions)
+    }
+    if (measurements != null) {
+        measurements.forEach { (name, value) -> assertEquals(value, view.measurements[name]) }
+        assertEquals(measurements.size, view.measurements.size)
+    }
+    if (distributions != null) {
+        assertEquals(distributions, view.distributions)
+    }
+}


### PR DESCRIPTION
also adds a `getView()` to Metrics which will help other users make unit tests for their own metrics