### PR TITLE
fix: Metrics.asGoofyOtlpMetricSequence also needs to append any shared dimensions from prescientSharedDimensions

### DIFF
--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/downstream/OpentelemetryClient.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/downstream/OpentelemetryClient.kt
@@ -242,7 +242,7 @@ class OpentelemetryClient(
 
 
     private fun Metrics.asGoofyOtlpMetricSequence(): Sequence<Metric> {
-        val otlpDimensions = metricDimensions.values.map { it.asOtlpKeyValue() }
+        val otlpDimensions = metricDimensions.values.map { it.asOtlpKeyValue() } + prescientSharedDimensions.sharedDimensions.asOtlpDimensions()
         return sequence {
             for ((measurementName, value) in this@asGoofyOtlpMetricSequence.metricMeasurements) {
                 yield(


### PR DESCRIPTION
If downstream consumers create gauges, shared dimensions won't be added. Missed this before since `asGoofyOtlpMetricSequence` shares the same name with the `AggregatedBatch` extension function. This commit should fix the bug.
